### PR TITLE
Add libicu libraries to devcontainer dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,3 +13,6 @@ RUN apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
     && chmod 0440 /etc/sudoers.d/$USERNAME 
+
+# Install Live Share dependencies
+RUN apt-get install -y --no-install-recommends libicu[0-9][0-9] libkrb5-3 openssl zlib1g


### PR DESCRIPTION
Checked that live share works from inside the remote container on linux mint (mine) and on a non-M1 Mac ( @kylehoehns ). Can also be tested on a windows machine and an M1 mac if we want to be through. 

Unsure if this needs to go in the template project instead. 